### PR TITLE
Make years not be hardcoded

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -7,7 +7,17 @@ import * as mutationTypes from './mutation-types';
 
 export function fetchYears({ commit }) {
   commit(mutationTypes.SET_YEARS_LOADING, true);
-  return Promise.resolve([2017])
+  const years = [];
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  // If we are in the second semester, use the base year instead of the actual current year
+  // For example, January of 2020 is 2020 but it is the second semester of 2019/2020
+  // Thus, the actual year should be 2019
+  const currentSchoolYear = today.getMonth() < 7 ? currentYear - 1 : currentYear;
+  for (let year = 2017; year <= currentSchoolYear; ++year) {
+    years.push(year);
+  }
+  return Promise.resolve(years)
     .then(data => commit(mutationTypes.SET_YEARS, data));
 }
 


### PR DESCRIPTION
This makes it so that the year-selection dropdown no longer has a single hardcoded year (and a ghost option that is added due to selecting the current year in a component mount... :upside_down_face:).

This is not super ideal, since when we get to January there will be one extra year, but it is an easy solution and that extra year is inconsequential imo. (Tbh, could just clone the logic from the component mount and call it a day :upside_down_face:)

This is important to merge in order to ensure that the code will work for longer, instead of there being a need to add more years to the year array every now and then (was done in niserver directly, to speed things up, but resulted in dirty state, which I would like to avoid :sweat_smile:).