### PR TITLE
Reorganize schedule selector in mobile mode

### DIFF
--- a/src/components/planner/Schedule.tsx
+++ b/src/components/planner/Schedule.tsx
@@ -237,12 +237,12 @@ const Schedule = ({ courseOptions }: Props) => {
       </div>
 
       {/* Schedule Mobile */}
-      <div className="flex h-full w-full flex-col items-center justify-start space-y-2 lg:hidden gap-2">
+      <div className="flex h-full w-full flex-col items-center justify-start gap-2 space-y-2 lg:hidden">
         {lessonsGroupedByDays.length > 0 ? (
           lessonsGroupedByDays.map((lessons: Lesson[], dayNumber: number) => (
             <div className="flex w-full items-center justify-start gap-2" key={`responsive-lesson-row-${dayNumber}`}>
-              <div className="flex h-full w-4 rounded bg-primary">
-                <strong className='text-white text-xl'>{convertWeekdayLong(dayNumber)[0]}</strong>
+              <div className="flex h-full rounded bg-primary p-1">
+                <strong className="text-xl text-white">{convertWeekdayLong(dayNumber)[0]}</strong>
               </div>
               <div className="flex w-full flex-row flex-wrap items-center justify-start gap-2">
                 {lessons.map(

--- a/src/components/planner/Schedule.tsx
+++ b/src/components/planner/Schedule.tsx
@@ -237,11 +237,13 @@ const Schedule = ({ courseOptions }: Props) => {
       </div>
 
       {/* Schedule Mobile */}
-      <div className="flex h-full w-full flex-col items-center justify-start space-y-2 lg:hidden">
+      <div className="flex h-full w-full flex-col items-center justify-start space-y-2 lg:hidden gap-2">
         {lessonsGroupedByDays.length > 0 ? (
           lessonsGroupedByDays.map((lessons: Lesson[], dayNumber: number) => (
             <div className="flex w-full items-center justify-start gap-2" key={`responsive-lesson-row-${dayNumber}`}>
-              <div className="h-full w-1 rounded bg-primary" />
+              <div className="flex h-full w-4 rounded bg-primary">
+                <strong className='text-white text-xl'>{convertWeekdayLong(dayNumber)[0]}</strong>
+              </div>
               <div className="flex w-full flex-row flex-wrap items-center justify-start gap-2">
                 {lessons.map(
                   (lesson: Lesson, lessonIdx: number) =>

--- a/src/components/planner/Sidebar.tsx
+++ b/src/components/planner/Sidebar.tsx
@@ -111,7 +111,7 @@ const Sidebar = ({
   }, [selectedOption])
 
   return (
-    <div className="lg:min-h-adjusted order-2 col-span-12 flex min-h-min flex-col-reverse lg:flex-col justify-between rounded bg-lightest px-5 py-5 justify-center dark:bg-dark lg:col-span-3 2xl:px-4 2xl:py-4 lg:justify-start">
+    <div className="lg:min-h-adjusted order-2 col-span-12 flex min-h-min flex-col rounded bg-lightest px-5 py-5 justify-start dark:bg-dark lg:col-span-3 2xl:px-4 2xl:py-4 items-start">
         <SessionController
           majors={majors}
           openHook={openHook}

--- a/src/components/planner/Sidebar.tsx
+++ b/src/components/planner/Sidebar.tsx
@@ -111,43 +111,39 @@ const Sidebar = ({
   }, [selectedOption])
 
   return (
-    <div className="lg:min-h-adjusted order-2 col-span-12 flex min-h-min flex-col justify-between rounded bg-lightest px-3 py-3 dark:bg-dark lg:col-span-3 2xl:px-4 2xl:py-4">
-      <div className="space-y-2">
-        <div className="relative flex flex-row flex-wrap items-center justify-center gap-x-2 gap-y-2 lg:justify-start">
-          <SessionController
-            majors={majors}
-            openHook={openHook}
-            majorHook={majorHook}
-            coursesHook={coursesHook}
-            extraCoursesActiveHook={extraCoursesActiveHook}
-            extraCoursesModalOpenHook={extraCoursesModalOpenHook}
-            sourceBufferHook={sourceBufferHook}
-            destBufferHook={destBufferHook}
-            repeatedCourseControlHook={repeatedCourseControlHook}
-            multipleOptions={multipleOptions}
-            optionsList={optionsList}
-          />
-          <OptionsController
-            multipleOptionsHook={multipleOptionsHook}
-            optionsListHook={[optionsList, setOptionsList]}
-            selectedOptionHook={[selectedOption, setSelectedOption]}
-          />
-          <SelectedOptionController
-            optionsListHook={[optionsList, setOptionsList]}
-            selectedOptionHook={[selectedOption, setSelectedOption]}
-            majors={majors}
-            majorHook={majorHook}
-            currentOption={multipleOptions.selected}
-            multipleOptionsHook={multipleOptionsHook}
-            checkCourses={checkCourses}
-            isImportedOptionHook={[isImportedOption, setImportedOption]}
-          />
-          <CoursesController
-            multilpleOptionsHook={multipleOptionsHook}
-            isImportedOptionHook={[isImportedOption, setImportedOption]}
-          />
-        </div>
-      </div>
+    <div className="lg:min-h-adjusted order-2 col-span-12 flex min-h-min flex-col-reverse lg:flex-col justify-between rounded bg-lightest px-5 py-5 justify-center dark:bg-dark lg:col-span-3 2xl:px-4 2xl:py-4 lg:justify-start">
+        <SessionController
+          majors={majors}
+          openHook={openHook}
+          majorHook={majorHook}
+          coursesHook={coursesHook}
+          extraCoursesActiveHook={extraCoursesActiveHook}
+          extraCoursesModalOpenHook={extraCoursesModalOpenHook}
+          sourceBufferHook={sourceBufferHook}
+          destBufferHook={destBufferHook}
+          repeatedCourseControlHook={repeatedCourseControlHook}
+          multipleOptions={multipleOptions}
+          optionsList={optionsList}
+        />
+        <OptionsController
+          multipleOptionsHook={multipleOptionsHook}
+          optionsListHook={[optionsList, setOptionsList]}
+          selectedOptionHook={[selectedOption, setSelectedOption]}
+        />
+        <SelectedOptionController
+          optionsListHook={[optionsList, setOptionsList]}
+          selectedOptionHook={[selectedOption, setSelectedOption]}
+          majors={majors}
+          majorHook={majorHook}
+          currentOption={multipleOptions.selected}
+          multipleOptionsHook={multipleOptionsHook}
+          checkCourses={checkCourses}
+          isImportedOptionHook={[isImportedOption, setImportedOption]}
+        />
+        <CoursesController
+          multilpleOptionsHook={multipleOptionsHook}
+          isImportedOptionHook={[isImportedOption, setImportedOption]}
+        />
     </div>
   )
 }

--- a/src/components/planner/schedules/ResponsiveLessonBox.tsx
+++ b/src/components/planner/schedules/ResponsiveLessonBox.tsx
@@ -26,9 +26,28 @@ const ResponsiveLessonBox = ({ lesson, conflict }: Props) => {
       <div
         className={classNames(
           'p-2 text-sm leading-none tracking-tighter text-white',
-          'flex h-full w-full flex-col items-center justify-between gap-6'
+          'flex h-full w-full flex-col items-center justify-between gap-4'
         )}
       >
+        <div className='flex w-full justify-between gap-2'>
+          <strong title="Sigla da Unidade Curricular" className='text-lg'>{lesson.course.acronym}</strong>
+          <span title={getLessonTypeLongName(lessonType)} className='text-lg'>{lessonType}</span>
+        </div>
+
+        <div className="flex flex-col">
+          <span title="Duração">{getLessonBoxTime(lesson.schedule)}</span>
+          <span title="Nome da Turma">
+            {lesson.schedule.composed_class_name ? lesson.schedule.composed_class_name : lesson.schedule.class_name}
+          </span>
+        </div>
+
+        <div className='flex w-full justify-between'>
+          <span title="Sala">{lesson.schedule.location}</span>
+          <span title="Professor(es)" className="whitespace-nowrap">
+            {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
+          </span>
+        </div>
+        {/*
         <div className="flex w-full flex-col justify-between gap-2">
           <span className="flex w-full items-center justify-between">
             <strong title="Dia">{convertWeekdayLong(lesson.schedule.day)}</strong>
@@ -50,6 +69,8 @@ const ResponsiveLessonBox = ({ lesson, conflict }: Props) => {
             {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
           </span>
         </div>
+        */}
+        
       </div>
     </div>
   )

--- a/src/components/planner/sidebar/OptionsController.tsx
+++ b/src/components/planner/sidebar/OptionsController.tsx
@@ -67,7 +67,7 @@ const OptionsController = ({ multipleOptionsHook, optionsListHook, selectedOptio
 
   return (
     <ReactSortable
-      className="m-y-2 flex flex-row justify-start gap-2 overflow-x-auto py-2 text-center"
+      className="m-y-2 flex flex-row justify-center gap-2 overflow-x-auto py-2 text-center w-full lg:justify-start"
       list={optionsList}
       setList={setOptionsList}
       group="groupName"

--- a/src/pages/TimeTableScheduler.tsx
+++ b/src/pages/TimeTableScheduler.tsx
@@ -398,7 +398,7 @@ const TimeTableSchedulerPage = () => {
   return (
     <div className="grid w-full grid-cols-12 gap-x-4 gap-y-4 px-4 py-4">
       {/* Schedule Preview */}
-      <div className="lg:min-h-adjusted order-1 col-span-12 min-h-min rounded bg-lightest px-3 py-3 dark:bg-dark lg:col-span-9 2xl:px-5 2xl:py-5">
+      <div className="lg:min-h-adjusted order-3 lg:order-1 col-span-12 min-h-min rounded bg-lightest px-3 py-3 dark:bg-dark lg:col-span-9 2xl:px-5 2xl:py-5">
         <div className="h-full w-full">
           <Schedule courseOptions={multipleOptions.selected} />
         </div>


### PR DESCRIPTION
Closes #149 

For a smaller screen, the schedule and sidebar design changes. When the page is small, the schedule emphasizes the course and more important information and the schedule card goes to the end of the page.
