### PR TITLE
Course api year is now dynamic

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -6,6 +6,9 @@ const BE_CONFIG = Number(prod_val) ? config : dev_config
 const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL || `${BE_CONFIG.api.protocol}://${BE_CONFIG.api.host}:${BE_CONFIG.api.port}${BE_CONFIG.api.pathPrefix}`
 const SEMESTER = import.meta.env.VITE_APP_SEMESTER || getSemester()
 
+// If we are in september 2024 we use 2024, if we are january 2025 we use 2024 because the first year of the academic year (2024/2025)
+const CURRENT_YEAR = ((new Date()).getMonth() + 1) < 8 ? (new Date()).getFullYear() - 1 : (new Date()).getFullYear()
+
 /**
  * Make a request to the backend server.
  * @param route route to be appended to backend url
@@ -27,7 +30,7 @@ const apiRequest = async (route: string) => {
  * @returns all majors from the backend
  */
 const getMajors = async () => {
-  return await apiRequest(`/course/${config.api.year}`)
+  return await apiRequest(`/course/${CURRENT_YEAR}`)
 }
 
 /**
@@ -41,7 +44,7 @@ const getCourses = async (major: Major) => {
 }
 
 const getCoursesByMajorId = async (id: number) => {
-  return await apiRequest(`/course_units/${id}/${config.api.year}/${SEMESTER}/`)
+  return await apiRequest(`/course_units/${id}/${CURRENT_YEAR}/${SEMESTER}/`)
 }
 
 /**

--- a/src/config/local.json
+++ b/src/config/local.json
@@ -14,7 +14,6 @@
     "port": 8100,
     "protocol" : "http",
     "pathPrefix": "",
-    "host": "localhost",
-    "year": 2023
+    "host": "localhost"
   }
 }

--- a/src/config/prod.json
+++ b/src/config/prod.json
@@ -13,7 +13,6 @@
     "port": 443,
     "protocol" : "https",
     "host": "ni.fe.up.pt",
-    "pathPrefix" : "/tts/api",
-    "year": 2023
+    "pathPrefix" : "/tts/api"
   }
 }


### PR DESCRIPTION
As the same thing that was done on this [scrapper pr](https://github.com/NIAEFEUP/uporto-schedule-scrapper/pull/116), the year should not be static and instead dynamic.

This way we don't need to touch it while in deployment to alter the configuration file for the year