### PR TITLE
FIX: picked courses are now being correctly stored

### DIFF
--- a/src/components/planner/sidebar/sessionController/CoursePicker.tsx
+++ b/src/components/planner/sidebar/sessionController/CoursePicker.tsx
@@ -33,9 +33,9 @@ const CoursePicker = () => {
 
   useEffect(() => {
     BackendAPI.getCoursesClasses(checkboxedCourses).then((courseWithClasses) => {
+      StorageAPI.setPickedCoursesStorage(courseWithClasses);
       setPickedCourses(courseWithClasses);
     })
-    StorageAPI.setPickedCoursesStorage(pickedCourses)
   }, [checkboxedCourses])
 
   useEffect(() => {


### PR DESCRIPTION
I noticed that the picked courses were disappearing when we refreshed the page. 

It is now fixed with this PR, it was some weird bug related to promises again.