### PR TITLE
fix: make deploy action use branch environment

### DIFF
--- a/.github/workflows/niployments.yaml
+++ b/.github/workflows/niployments.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
 
     steps:
     - name: Upload to NIployments register


### PR DESCRIPTION
When we separated the secrets per environment depending on the branch, we didn't add correctly adapt the action workflow.

This PR takes care of that.