### PR TITLE
fix: schedule preview is restored on esc

### DIFF
--- a/src/components/planner/sidebar/CoursesController/ClassSelector.tsx
+++ b/src/components/planner/sidebar/CoursesController/ClassSelector.tsx
@@ -203,7 +203,12 @@ const ClassSelector = ({ course }: Props) => {
       </p>
       <div className="flex items-center">
         {/* Dropdown Menu */}
-        <DropdownMenu onOpenChange={setIsDropdownOpen}>
+        <DropdownMenu onOpenChange={(open: boolean) => {
+          setIsDropdownOpen(open);
+          if (!open) {
+            removePreview();
+          }
+        }}>
           <DropdownMenuTrigger asChild disabled={courseOption?.locked} ref={classSelectorTriggerRef}>
             <Button
               variant="outline"


### PR DESCRIPTION
Closes #267 

When we are previewing a schedule of a class and we press the `ESC` key in order to make the modal disappear, prior to this PR the class that would remain would be the previewed one and not the original one.