### PR TITLE
fix: pasting ghost schedule option

### DIFF
--- a/src/components/planner/sidebar/selectedOptionController/CopyOption.tsx
+++ b/src/components/planner/sidebar/selectedOptionController/CopyOption.tsx
@@ -26,8 +26,9 @@ const CopyOption = ({ currentOption, className }: Props) => {
 
   //TODO (thePeras): Add link here
   const optionToString = (selectedOption: CourseOption[]) => {
+    if (selectedOption.filter((course) => !course.picked_class_id).length === selectedOption.length) return "";
+
     const copyOption = selectedOption.map((element) => {
-      if (!element.picked_class_id) return '';
       return element.course_id + '#' + element.picked_class_id;
     }).join(';');
 
@@ -35,9 +36,15 @@ const CopyOption = ({ currentOption, className }: Props) => {
   }
 
   const copyOption = () => {
-    navigator.clipboard.writeText(optionToString(currentOption))
-    setIcon(true)
-    toast({ title: 'Horário copiado', description: 'Podes colar o horário noutra opção ou enviar a um amigo.' })
+    const scheduleHash = optionToString(currentOption);
+    navigator.clipboard.writeText(scheduleHash);
+    setIcon(true);
+
+    if (scheduleHash === "") {
+      toast({ title: 'Horário não copiado', description: 'Não tens nenhuma aula selecionada para copiar.' })
+    } else {
+      toast({ title: 'Horário copiado', description: 'Podes colar o horário noutra opção ou enviar a um amigo.' })
+    }
     setTimeout(() => {
       setIcon(false)
     }, 1500)

--- a/src/components/planner/sidebar/selectedOptionController/PasteOption.tsx
+++ b/src/components/planner/sidebar/selectedOptionController/PasteOption.tsx
@@ -35,11 +35,10 @@ const PasteOption = () => {
     const isImporteFromClipboard: boolean = value
 
     if (!isValidURL(decoded_url)) {
-
       const description = isImporteFromClipboard
         ? 'O texto do clipboard não é uma opção válida'
         : 'O texto inserido não é uma opção válida'
-      console.log(description)
+
       toast({
         title: 'Erro ao colar opção',
         description,


### PR DESCRIPTION
Closes #274 

The hash was accumulating the `''` for some reason, so the paste option was pasting ghost course units and it was broken. This PR fixes it.