### PR TITLE
fix: slot order logic now takes into account start time if days are the same

### DIFF
--- a/src/components/planner/Schedule.tsx
+++ b/src/components/planner/Schedule.tsx
@@ -64,9 +64,13 @@ const Schedule = () => {
   }, [classes])
 
   const slotsOrderedByDay = (slots: Array<SlotInfo>): Array<SlotInfo> => {
-    return slots.sort((slot1, slot2) => (
-      slot1.day - slot2.day
-    ));
+    return slots.sort((slot1, slot2) => {
+      if (slot1.day === slot2.day) {
+        return slot1.start_time - slot2.start_time;
+      }
+
+      return slot1.day - slot2.day
+    });
   }
 
   // Bottom Bar Configurations


### PR DESCRIPTION
As @jose-carlos-sousa noticed, if the slots were of the same day they weren't being sorted correctly as we weren't having the start time of the slots into account.

This PR fixes it.