### PR TITLE
fix: app crashing sometimes after refresh course unit hashes

### DIFF
--- a/src/components/planner/sidebar/CoursesController/ClassItem.tsx
+++ b/src/components/planner/sidebar/CoursesController/ClassItem.tsx
@@ -41,9 +41,13 @@ const ClassItem = ({ course_id, classInfo, displayed, checked, preview, onSelect
         // retrieve class with the picked class id of the course option
         const pickedClass = pickedCourse.classes.find(c => c.id === course_option.picked_class_id);
 
-        classes.push(pickedClass);
+        if (pickedClass) classes.push(pickedClass);
       }
     }
+
+    console.log("multiple options: ", { ...multipleOptions });
+    console.log("picked courses: ", [...pickedCourses]);
+    console.log("classes: ", classes);
 
     for (const pickedClass of classes)
       for (const slot1 of pickedClass.slots)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -316,7 +316,7 @@ const getAllPickedSlots = (selected_courses: PickedCourses, option: Option) => {
     if (!course.picked_class_id) return []
     const courseInfo = selected_courses.find((selected_course) => selected_course.id === course.course_id)
     const classInfo = courseInfo.classes.find((classInfo) => classInfo.id === course.picked_class_id)
-    if( !classInfo ) return [];
+    if (!classInfo) return [];
     return classInfo.slots
   })
 }


### PR DESCRIPTION
This bug happens when the class_id that comes from the backend changes. The multipleOptions still has the old picked_class_id, but there's no longer any class in the courses inside pickedCourses with the id that's in the picked_class_id, so what I've underlined is undefined and it's a mess.
Adding that if (pickedClass) on the last line (which isn't in the main, I added it locally to test the problem) stops the problem. The multiple options are not putting the picked_class_id associated with the course that was changed when that class ceased to exist.