### PR TITLE
fix: app crashing sometimes after refresh course unit hashes

### DIFF
--- a/src/components/planner/sidebar/CoursesController/ClassItem.tsx
+++ b/src/components/planner/sidebar/CoursesController/ClassItem.tsx
@@ -41,7 +41,7 @@ const ClassItem = ({ course_id, classInfo, displayed, checked, preview, onSelect
         // retrieve class with the picked class id of the course option
         const pickedClass = pickedCourse.classes.find(c => c.id === course_option.picked_class_id);
 
-        classes.push(pickedClass);
+        if (pickedClass) classes.push(pickedClass);
       }
     }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -316,7 +316,7 @@ const getAllPickedSlots = (selected_courses: PickedCourses, option: Option) => {
     if (!course.picked_class_id) return []
     const courseInfo = selected_courses.find((selected_course) => selected_course.id === course.course_id)
     const classInfo = courseInfo.classes.find((classInfo) => classInfo.id === course.picked_class_id)
-    if( !classInfo ) return [];
+    if (!classInfo) return [];
     return classInfo.slots
   })
 }


### PR DESCRIPTION
This is a highly severe bug, especially because it happens in one of our most used majors which is LEIC and completely crashes the app with the need of clearing the site data in order to make it work again.

This is a small and easy fix and there is a problem with random fill in the `develop` branch, so only this is included in this release branch.