### PR TITLE
fix: filtered teachers remain put

### DIFF
--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -108,6 +108,10 @@ const setMultipleOptionsStorage = (multipleOptions: MultipleOptions) => {
   writeStorage(key, multipleOptions);
 }
 
+const getCourseFilteredTeachersStorage = (selectedOption: number, courseUnitId: number) => {
+  return getMultipleOptionsStorage()[selectedOption].course_options.find((option) => option.course_id === courseUnitId).filteredTeachers;
+}
+
 const getSelectedOptionStorage = () => {
   const key = 'niaefeup-tts.selected-option';
 
@@ -165,6 +169,7 @@ const StorageAPI = {
   setSelectedMajorStorage,
   getPickedCoursesStorage,
   setPickedCoursesStorage,
+  getCourseFilteredTeachersStorage
 }
 
 export default StorageAPI

--- a/src/components/planner/sidebar/CoursesController/ClassSelector.tsx
+++ b/src/components/planner/sidebar/CoursesController/ClassSelector.tsx
@@ -16,7 +16,6 @@ type Props = {
   course: CourseInfo
 }
 
-//TODO: Check this code, not too good
 const ClassSelector = ({ course }: Props) => {
   const classSelectorTriggerRef = useRef(null)
   const classSelectorContentRef = useRef(null)
@@ -27,8 +26,6 @@ const ClassSelector = ({ course }: Props) => {
   const [selectedClassId, setSelectedClassId] = useState<number | null>(null);
 
   const courseOption: CourseOption = multipleOptions[selectedOption].course_options.find((opt) => opt.course_id === course.id)
-  if (courseOption)
-    courseOption.filteredTeachers = [...teacherIdsFromCourseInfo(course)];
 
   const [locked, setLocked] = useState(courseOption?.locked)
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -210,7 +210,7 @@ const convertCourseInfoToCourseOption = (course: CourseInfo): CourseOption => {
     course_id: course.id,
     picked_class_id: null,
     locked: false,
-    filteredTeachers: [],
+    filteredTeachers: null,
     hide: []
   }
 }
@@ -255,7 +255,7 @@ const createDefaultCourseOption = (course: CourseInfo): CourseOption => {
     course_id: course.id,
     picked_class_id: null,
     locked: false,
-    filteredTeachers: [],
+    filteredTeachers: null,
     hide: []
   }
 }


### PR DESCRIPTION
Closes #303 

Besides this bug being solved, the filters are now stored on local storage so when the user refreshes or comes back to the page, the teacher filters will stay put.