### PR TITLE
fix: collab session duplicate definition

### DIFF
--- a/src/components/planner/schedules/SlotBoxes.tsx
+++ b/src/components/planner/schedules/SlotBoxes.tsx
@@ -13,7 +13,7 @@ const SlotBoxes = ({ slots, classes, hiddenLessonsTypes }: Props) => {
   return (
     <>
       {
-        filteredSlots.map((slot: SlotInfo) => {
+        filteredSlots.map((slot: SlotInfo, idx: number) => {
           const classDescriptor = classes.find((classDescriptor) => (
             classDescriptor.classInfo.slots.filter((otherSlot) => otherSlot.id === slot.id).length > 0
           ))
@@ -21,7 +21,7 @@ const SlotBoxes = ({ slots, classes, hiddenLessonsTypes }: Props) => {
           if (!classDescriptor) return <></>;
 
           return <SlotBox
-            key={`${classDescriptor.courseInfo.id}-${classDescriptor.classInfo.id}`}
+            key={`${classDescriptor.courseInfo.id}-${classDescriptor.classInfo.id}-${idx}`}
             courseInfo={classDescriptor.courseInfo}
             classInfo={classDescriptor.classInfo}
             classes={classes}

--- a/src/components/planner/sidebar/sessionController/CollabModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabModal.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect, Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 import CollabPickSession from './CollabPickSession';
-import CollabSession from './CollabSession';
+import CollabSessionModal from './CollabSessionModal';
 import CollabSessionContext from '../../../../contexts/CollabSessionContext';
 
 const PICK_SESSION = 'PICK_SESSION';
@@ -125,7 +125,7 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
                 )}
 
                 {currentView === SESSION && currentSession && (
-                  <CollabSession
+                  <CollabSessionModal
                     session={currentSession}
                     onExitSession={handleExitSession}
                     onUpdateUser={handleUpdateUser}

--- a/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
@@ -19,7 +19,7 @@ type Props = {
   onUpdateUser: (arg: string) => void
 }
 
-const CollabSession = ({ session, onExitSession, onUpdateUser }: Props) => {
+const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => {
   const { toast } = useToast();
   const [copied, setCopied] = useState(false);
   const [lastValidUser, setLastValidUser] = useState(session.currentUser);
@@ -130,4 +130,4 @@ const CollabSession = ({ session, onExitSession, onUpdateUser }: Props) => {
   );
 };
 
-export default CollabSession;
+export default CollabSessionModal;


### PR DESCRIPTION
There was a modal called `<CollabSession>` and also a `index.ts` type named `CollabSession` and this was giving problems which was introduced in my pr about setting up a linter