### PR TITLE
fix: class conflict between T and two TPs

### DIFF
--- a/src/styles/schedule.css
+++ b/src/styles/schedule.css
@@ -158,7 +158,7 @@
 }
 
 .schedule-class-conflict {
-  @apply z-20 border-2 opacity-75 border-red-600 ring-rose-700 hover:z-30 hover:opacity-100 hover:ring-1;
+  @apply z-30 border-2 opacity-75 border-red-600 ring-rose-700 hover:z-30 hover:opacity-100 hover:ring-1;
 }
 
 .schedule-class-conflict-warn {
@@ -166,7 +166,7 @@
 }
 
 .schedule-class-conflict-info {
-  @apply z-20 border-2  border-red-600 opacity-75 ring-red-500 hover:z-30 hover:opacity-100;
+  @apply z-30 border-2  border-red-600 opacity-75 ring-red-500 hover:z-30 hover:opacity-100;
 }
 
 .schedule-class-conflict-warn-info {


### PR DESCRIPTION
Closes #313 

Conflicts between TPs (red) are shown above warnings between T and TPs (yellow).

![image](https://github.com/user-attachments/assets/e8f39384-6678-447a-905a-f9fda74c5659)
