### PR TITLE
Allow user to erase classes from option more easily

### DIFF
--- a/src/components/planner/sidebar/CoursesController.tsx
+++ b/src/components/planner/sidebar/CoursesController.tsx
@@ -19,6 +19,7 @@ const CoursesController = () => {
     const updatedCourseOptions = currentOption.course_options.map(courseOption => ({
       ...courseOption,
       picked_class_id: null,
+      locked: false,
     }));
   
     const updatedMultipleOptions = [...multipleOptions];

--- a/src/components/planner/sidebar/CoursesController.tsx
+++ b/src/components/planner/sidebar/CoursesController.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import ClassSelector from './CoursesController/ClassSelector'
 import CourseContext from '../../../contexts/CourseContext'
+import MultipleOptionsContext from '../../../contexts/MultipleOptionsContext'
 import { TrashIcon } from "@heroicons/react/24/outline"
 import { NoMajorSelectedSVG } from '../../svgs'
 import { Button } from '../../ui/button'
@@ -8,10 +9,26 @@ import { Button } from '../../ui/button'
 
 const CoursesController = () => {
   const { pickedCourses, setUcsModalOpen } = useContext(CourseContext);
+  const { multipleOptions, selectedOption, setMultipleOptions } = useContext(MultipleOptionsContext);
 
   const noCoursesPicked = pickedCourses.length === 0;
 
-  const eraseClasses = () => {  };
+  const eraseClasses = () => {
+    const currentOption = multipleOptions[selectedOption];
+  
+    const updatedCourseOptions = currentOption.course_options.map(courseOption => ({
+      ...courseOption,
+      picked_class_id: null,
+    }));
+  
+    const updatedMultipleOptions = [...multipleOptions];
+    updatedMultipleOptions[selectedOption] = {
+      ...currentOption,
+      course_options: updatedCourseOptions,
+    };
+  
+    setMultipleOptions(updatedMultipleOptions);
+  };
 
   return (
     <div className={`flex ${noCoursesPicked ? 'h-max justify-center' : ''} w-full flex-col gap-4 px-0 py-2`}>

--- a/src/components/planner/sidebar/CoursesController.tsx
+++ b/src/components/planner/sidebar/CoursesController.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import ClassSelector from './CoursesController/ClassSelector'
 import CourseContext from '../../../contexts/CourseContext'
+import { TrashIcon } from "@heroicons/react/24/outline"
 import { NoMajorSelectedSVG } from '../../svgs'
 import { Button } from '../../ui/button'
 
@@ -9,6 +10,9 @@ const CoursesController = () => {
   const { pickedCourses, setUcsModalOpen } = useContext(CourseContext);
 
   const noCoursesPicked = pickedCourses.length === 0;
+
+  const eraseClasses = () => {  };
+
   return (
     <div className={`flex ${noCoursesPicked ? 'h-max justify-center' : ''} w-full flex-col gap-4 px-0 py-2`}>
       {noCoursesPicked ? (
@@ -28,6 +32,20 @@ const CoursesController = () => {
             <ClassSelector course={course} key={`course-schedule-${courseIdx}-${course.id}`} />
           ))
       )}
+
+      {!noCoursesPicked && (
+        <div className="mt-4 flex justify-end">
+          <Button
+            onClick={eraseClasses}
+            variant="icon"
+            className="bg-lightish text-darkish gap-1.5"
+          >
+            <TrashIcon className="h-5 w-5" />
+            <span>Limpar</span>
+          </Button>
+        </div>
+      )}
+
     </div>
   )
 }


### PR DESCRIPTION
### Erase classes easily

Added a button that erases all selected classes in the current option.
Design is based on the button from the CoursePicker modal.

<img height=500 src=https://github.com/user-attachments/assets/9c2e43c3-49c9-4971-98ae-3a7ce0cfcd4a>
<img height=500 src=https://github.com/user-attachments/assets/3f06abb8-db53-4261-be43-bdade3cd7ce0>

#### Let me know your thoughts :)
##### (after approval) closes #319 