### PR TITLE
fix: sentry action could not find version

### DIFF
--- a/.github/workflows/sentry.yaml
+++ b/.github/workflows/sentry.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
           version: ${{ steps.get_version.outputs.release_version }}
+          ignore_missing: true
           sourcemaps: ./build
           finalize: true
         env:


### PR DESCRIPTION
As per the suggestion in the error message from the sentry action

![image](https://github.com/user-attachments/assets/618c1b3c-daf1-4380-a202-dcc7ba411e07)
