### PR TITLE
fix: invalid url to sso login

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -5,8 +5,8 @@ import Cookies from 'js-cookie'
 const prod_val = import.meta.env.VITE_APP_PROD
 const BE_CONFIG = Number(prod_val) ? config : dev_config
 const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL || `${BE_CONFIG.api.protocol}://${BE_CONFIG.api.host}:${BE_CONFIG.api.port}${BE_CONFIG.api.pathPrefix}`
-const OIDC_LOGIN_URL = `${BACKEND_URL}/oidc-auth/authenticate`
-const OIDC_LOGOUT_URL = `${BACKEND_URL}/oidc-auth/logout`
+const OIDC_LOGIN_URL = `${BACKEND_URL}/oidc-auth/authenticate/`
+const OIDC_LOGOUT_URL = `${BACKEND_URL}/oidc-auth/logout/`
 const SEMESTER = import.meta.env.VITE_APP_SEMESTER || getSemester()
 
 // If we are in september 2024 we use 2024, if we are january 2025 we use 2024 because the first year of the academic year (2024/2025)


### PR DESCRIPTION
Adding a slash to the end of the login and logout urls solve the issue we are having in tts-staging.niaefeup.pt of the fact that clicking on the button or in the login icon does not correctly redirect to the backend.