### PR TITLE
Fix T-class conflicts on normal planner

### DIFF
--- a/src/components/exchange/schedule/ExchangeSchedule.tsx
+++ b/src/components/exchange/schedule/ExchangeSchedule.tsx
@@ -2,11 +2,13 @@ import { useContext, useEffect, useState } from "react";
 import { ClassDescriptor, SlotInfo } from "../../../@types";
 import ScheduleContext from "../../../contexts/ScheduleContext";
 import { Schedule } from "../../planner";
+import ConflictsContext from "../../../contexts/ConflictsContext";
 
 const ExchangeSchedule = () => {
   const { exchangeSchedule } = useContext(ScheduleContext);
   const [slots, setSlots] = useState<SlotInfo[]>([]);
   const [classes, setClasses] = useState<ClassDescriptor[]>([]);
+  const { setTClassConflicts } = useContext(ConflictsContext);
 
   useEffect(() => {
     if (!exchangeSchedule) return;
@@ -47,6 +49,12 @@ const ExchangeSchedule = () => {
     if (praticalClass) return praticalClass.classInfo.name;
     return classes[0].classInfo.name;
   };
+
+  // Configure T-class conflicts based on environment variable
+  useEffect(() => {
+    const tClassConflicts = Number(import.meta.env.VITE_APP_T_CLASS_CONFLICTS) !== 0;
+    setTClassConflicts(tClassConflicts);
+  }, []);
 
   return <Schedule
       classes={classes}

--- a/src/components/planner/schedule/PlannerSchedule.tsx
+++ b/src/components/planner/schedule/PlannerSchedule.tsx
@@ -3,12 +3,14 @@ import { ClassDescriptor, SlotInfo } from "../../../@types";
 import CourseContext from "../../../contexts/CourseContext";
 import MultipleOptionsContext from "../../../contexts/MultipleOptionsContext";
 import Schedule from "../Schedule";
+import ConflictsContext from "../../../contexts/ConflictsContext";
 
 const PlannerSchedule = () => {
   const { pickedCourses } = useContext(CourseContext);
   const { multipleOptions, selectedOption } = useContext(MultipleOptionsContext);
   const [classes, setClasses] = useState<ClassDescriptor[]>([]);
   const [slots, setSlots] = useState<SlotInfo[]>([]);
+  const { setTClassConflicts } = useContext(ConflictsContext);
 
   useEffect(() => {
     //TODO: Improvements by functional programming
@@ -33,6 +35,10 @@ const PlannerSchedule = () => {
     setSlots(newClasses.map((newClass) => newClass.classInfo.slots).flat())
   }, [multipleOptions, pickedCourses, selectedOption])
 
+  // Disable T-class conflicts
+  useEffect(() => {
+    setTClassConflicts(false)
+  }, []);
 
   return <Schedule
     classes={classes}

--- a/src/components/planner/schedules/LessonBox.tsx
+++ b/src/components/planner/schedules/LessonBox.tsx
@@ -61,7 +61,7 @@ const LessonBox = ({
         const slot = classDescriptor.classInfo.slots[j];
         if (schedulesConflict(slotInfo, slot)) {
           // The highest severity of the all the conflicts is the overall severity
-          newConflictInfo.severe = conflictsSeverity(slotInfo, slot) == 2 || newConflictInfo.severe;
+          newConflictInfo.severe = conflictsSeverity(slotInfo, slot, Number(import.meta.env.VITE_APP_T_CLASS_CONFLICTS) != 0) == 2 || newConflictInfo.severe;
           const newClassDescriptor = {
             classInfo: classDescriptor.classInfo,
             courseInfo: classDescriptor.courseInfo,

--- a/src/components/planner/schedules/LessonBox.tsx
+++ b/src/components/planner/schedules/LessonBox.tsx
@@ -4,6 +4,7 @@ import LessonPopover from './LessonPopover'
 import ConflictsPopover from './ConflictsPopover'
 import { CourseInfo, ClassInfo, SlotInfo, ClassDescriptor, ConflictInfo } from '../../../@types'
 import { getLessonBoxTime, schedulesConflict, conflictsSeverity, getLessonBoxStyles, maxHour, minHour, getClassTypeClassName, getLessonTypeLongName } from '../../../utils'
+import ConflictsContext from '../../../contexts/ConflictsContext'
 import ScheduleContext from '../../../contexts/ScheduleContext'
 
 type Props = {
@@ -18,7 +19,7 @@ const LessonBox = ({
   courseInfo,
   classInfo,
   slotInfo,
-  classes, 
+  classes,
   setLessonBoxConflict
 }: Props) => {
   const classTitle = classInfo.name
@@ -42,6 +43,7 @@ const LessonBox = ({
   const [isHovered, setIsHovered] = useState(false)
   const [conflict, setConflict] = useState(conflicts[slotInfo.id]);
   const hasConflict = conflict?.conflictingClasses?.length > 1;
+  const { tClassConflicts } = useContext(ConflictsContext);
   const {originalExchangeSchedule} = useContext(ScheduleContext);
 
   // Needs to change the entry with the id of this lesson to contain the correct ConflictInfo when the classes change
@@ -61,7 +63,7 @@ const LessonBox = ({
         const slot = classDescriptor.classInfo.slots[j];
         if (schedulesConflict(slotInfo, slot)) {
           // The highest severity of the all the conflicts is the overall severity
-          newConflictInfo.severe = conflictsSeverity(slotInfo, slot, Number(import.meta.env.VITE_APP_T_CLASS_CONFLICTS) != 0) == 2 || newConflictInfo.severe;
+          newConflictInfo.severe = conflictsSeverity(slotInfo, slot, tClassConflicts) == 2 || newConflictInfo.severe;
           const newClassDescriptor = {
             classInfo: classDescriptor.classInfo,
             courseInfo: classDescriptor.courseInfo,
@@ -71,13 +73,13 @@ const LessonBox = ({
         }
       }
     }
-    
+
     const hasNewClasses = !newConflictInfo.conflictingClasses.every((conflictingClass) => originalExchangeSchedule.some((originalClass) => originalClass.classInfo.id === conflictingClass.classInfo.id));
 
     if(!hasNewClasses && newConflictInfo.severe) {
       newConflictInfo.severe = false;
     }
-    
+
     setConflict(newConflictInfo);
   }, [classInfo, classes, hasConflict]);
 
@@ -150,7 +152,7 @@ const LessonBox = ({
 
             {lgLesson && (
               <div
-                className={`flex h-full w-full flex-col items-center justify-between p-1 text-xxs leading-none tracking-tighter text-white 
+                className={`flex h-full w-full flex-col items-center justify-between p-1 text-xxs leading-none tracking-tighter text-white
               ${conflictTitle ? 'group-hover:blur-md' : ''} lg:p-1.5 xl:text-xs 2xl:p-2 2xl:text-xs`}
               >
                 {/* Top */}
@@ -186,7 +188,7 @@ const LessonBox = ({
             {mdLesson && (
               <div
                 className={`flex h-full w-full flex-col items-center justify-between px-1 py-0.5 text-[0.55rem] tracking-tighter ${conflictTitle ? 'group-hover:blur-md' : ''
-                  } 
+                  }
               xl:text-xxs 2xl:px-1 2xl:py-0.5 2xl:text-[0.68rem]`}
               >
                 <div className="flex w-full items-center justify-between gap-1">
@@ -209,7 +211,7 @@ const LessonBox = ({
             )}
             {smLesson && (
               <div
-                className={`flex h-full w-full items-center justify-between gap-1 px-1 py-0.5 text-[0.55rem] tracking-tighter 
+                className={`flex h-full w-full items-center justify-between gap-1 px-1 py-0.5 text-[0.55rem] tracking-tighter
                 ${conflictTitle ? 'group-hover:blur-md' : ''} xl:text-xxs 2xl:px-1 2xl:py-1 2xl:text-[0.6rem]`}
               >
                 <span title="Duração">{timeSpan}</span>

--- a/src/components/planner/sidebar/CoursesController/ClassItem.tsx
+++ b/src/components/planner/sidebar/CoursesController/ClassItem.tsx
@@ -43,7 +43,7 @@ const ClassItem = ({ course_id, classInfo, onSelect, onMouseEnter, onMouseLeave 
 
     let maxSeverity = 0;
     for (const otherClass of otherClasses) {
-      maxSeverity = Math.max(maxSeverity, classesConflictSeverity(classInfo, otherClass)); 
+      maxSeverity = Math.max(maxSeverity, classesConflictSeverity(classInfo, otherClass, false));
     }
 
     return maxSeverity;

--- a/src/contexts/CombinedProvider.tsx
+++ b/src/contexts/CombinedProvider.tsx
@@ -39,6 +39,7 @@ const CombinedProvider = ({ children }: Props) => {
   }, [userSignedIn]);
 
   const [isConflictSevere, setConflictSeverity] = useState<boolean>(false);
+  const [tClassConflicts, setTClassConflicts] = useState<boolean>(false);
 
   const setMultipleOptions = (newMultipleOptions: MultipleOptions | ((prevMultipleOptions: MultipleOptions) => MultipleOptions)) => {
     if (newMultipleOptions instanceof Function)
@@ -70,7 +71,7 @@ const CombinedProvider = ({ children }: Props) => {
             }
           }>
             <MultipleOptionsContext.Provider value={{ multipleOptions, setMultipleOptions, selectedOption, setSelectedOption }}>
-              <ConflictsContext.Provider value={{ isConflictSevere, setConflictSeverity }}>
+              <ConflictsContext.Provider value={{ isConflictSevere, setConflictSeverity, tClassConflicts, setTClassConflicts }}>
                 {children}
               </ConflictsContext.Provider>
             </MultipleOptionsContext.Provider>

--- a/src/contexts/ConflictsContext.tsx
+++ b/src/contexts/ConflictsContext.tsx
@@ -3,11 +3,15 @@ import { Context, Dispatch, createContext, SetStateAction } from "react";
 interface ConflictsContextType {
     isConflictSevere: boolean;
     setConflictSeverity: Dispatch<SetStateAction<boolean>>;
+    tClassConflicts: boolean;
+    setTClassConflicts: Dispatch<SetStateAction<boolean>>;
 }
 
 const ConflictsContext: Context<ConflictsContextType> = createContext({
     isConflictSevere: false,
     setConflictSeverity: () => { },
+    tClassConflicts: false,
+    setTClassConflicts: () => { },
 })
 
 export default ConflictsContext

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,8 +9,6 @@ const maxHour = 23
 const dayNames = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab']
 const monthNames = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez']
 
-const T_CLASS_CONFLICTS = Number(import.meta.env.VITE_APP_T_CLASS_CONFLICTS)
-
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -71,21 +69,21 @@ const convertHour = (hourNumber: string) => {
   return `${hour}:${minutes}`
 }
 
-const isMandatory = (slot: SlotInfo): boolean => {
-  return (T_CLASS_CONFLICTS || slot.lesson_type !== 'T') && slot.lesson_type !== 'O';
+const isMandatory = (slot: SlotInfo, tClassConflict: boolean): boolean => {
+  return (tClassConflict || slot.lesson_type !== 'T') && slot.lesson_type !== 'O';
 }
 
-const conflictsSeverity = (first: SlotInfo, second: SlotInfo): number => {
-  return (isMandatory(first) && isMandatory(second)) ? 2 : 1;
+const conflictsSeverity = (first: SlotInfo, second: SlotInfo, tClassConflict: boolean): number => {
+  return (isMandatory(first, tClassConflict) && isMandatory(second, tClassConflict)) ? 2 : 1;
 }
 
-const classesConflictSeverity = (first: ClassInfo, second: ClassInfo): number => {
+const classesConflictSeverity = (first: ClassInfo, second: ClassInfo, tClassConflict: boolean): number => {
   let maxSeverity = 0;
 
   for (const slot of first.slots) {
     for (const otherSlot of second.slots) {
       if (schedulesConflict(slot, otherSlot)) {
-        maxSeverity = Math.max(maxSeverity, conflictsSeverity(slot, otherSlot));
+        maxSeverity = Math.max(maxSeverity, conflictsSeverity(slot, otherSlot, tClassConflict));
       }
     }
   }


### PR DESCRIPTION
Fixes an weird (and not so surprising) behavior, where setting `VITE_APP_T_CLASS_CONFLICTS=1` will result in conflicts with theoretical classes appearing in red in the normal planner. This still need to be discussed, as it complicates unnecessarily the logic for a somewhat unreasonable requirement from the course's board.

To test this PR, do not forget to set `VITE_APP_T_CLASS_CONFLICTS=1` in your `.env` file.