### PR TITLE
fix: better conflict text to indicate conflicts may not happen with us

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,5 +1,5 @@
 export const exchangeErrorToText = {
-    "classes-overlap": "Ao realizar esta troca, terias conflitos.",
+    "classes-overlap": "Ao realizar esta troca, haveriam conflitos para alguma pessoa envolvida na troca.",
     "students-with-incorrect-classes": "Alguma das pessoas envolvidas não está numa das turmas incluídas na troca.",
     "duplicate-request": "Já existe um pedido de troca igual a este.",
 }


### PR DESCRIPTION
Instead of "tens conflitos", it now says "alguém na troca", because we may not have conflicts but other people may do