### PR TITLE
fix: base64 jwt decode in url

### DIFF
--- a/src/api/services/exchangeRequestService.ts
+++ b/src/api/services/exchangeRequestService.ts
@@ -94,6 +94,7 @@ const adminMarkRequestAsAwaitingInformation = async (requestType: AdminRequestTy
 }
 
 const verifyExchangeRequest = async (token: string): Promise<boolean>=> {
+  token = atob(token);
   return fetch(`${api.BACKEND_URL}/exchange/verify/${token}`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
jwt with dots is messing up the nginx in the production build on the frontend
