### PR TITLE
fix: change logout button variant from secondary to destructive

### DIFF
--- a/src/components/auth/HeaderProfileDropdown.tsx
+++ b/src/components/auth/HeaderProfileDropdown.tsx
@@ -45,7 +45,7 @@ export const HeaderProfileDropdown = () => {
           />
           :
           <Button
-            variant="secondary"
+            variant="destructive"
             className="w-full flex flex-row justify-center gap-2"
             onClick={logout}
           >


### PR DESCRIPTION
### Description
This PR fixes [#558](https://github.com/NIAEFEUP/tts-fe/issues/558).

The logout button previously used the same style as the login button (`secondary` variant), which caused confusion.  
This change updates the logout button to use the `destructive` variant to visually differentiate it.

### Changes
- Updated `LogoutButton` variant from `secondary` → `destructive`
- Verified that the login button remains unchanged
- Tested in both light and dark mode

### Screenshots

<img width="438" height="199" alt="image" src="https://github.com/user-attachments/assets/e0edbfc4-9dbe-4e6f-9bee-6aae5133547f" />


<img width="478" height="202" alt="image" src="https://github.com/user-attachments/assets/1c1a00ef-e78b-48ae-be51-311ae6338c4a" />



### Related Issue
Fixes #558
