### PR TITLE
fix: Clarify the difference between /planner and /exchange

### DIFF
--- a/src/pages/TimeTableSelector.tsx
+++ b/src/pages/TimeTableSelector.tsx
@@ -67,7 +67,7 @@ const Content = () => {
         <div className="col-span-12 mb-2">
           <Alert type={AlertType.info}>
             <AlertDescription>
-              Este horário é apenas uma simulação (Planner). As trocas reais de turma só são efetuadas na página de Trocas de Turmas.
+              Esta secção funciona apenas como Planner de horários. As inscrições e trocas reais são realizadas na página de Inscrições e Trocas de Turmas.
             </AlertDescription>
           </Alert>
         </div>


### PR DESCRIPTION
# UI Screenshots

## Light mode
| Before | After |
| :---: | :---: |
| <img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/0453c07b-bd30-4590-8bb6-94e75c949d77" /> | <img width="1920" height="1200" alt="Screenshot From 2025-12-02 15-10-41" src="https://github.com/user-attachments/assets/11a8da09-eb28-4fc3-8e13-c9b16e8c0d35" /> |

## Dark mode
| Before | After |
| :---: | :---: |
| <img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/1ff1427d-2da5-4a18-927a-60775a8d93d7" />| <img width="1920" height="1200"  alt="Screenshot From 2025-12-02 15-10-54" src="https://github.com/user-attachments/assets/862e3a26-f497-4cb9-be59-508a4c7e775f" /> |
