### PR TITLE
Fixed frontend bugs in socket.ts and CollabModal.tsx

### DIFF
--- a/src/api/socket.ts
+++ b/src/api/socket.ts
@@ -81,7 +81,7 @@ class SessionsSocket {
     }
 
     isConnected() {
-        this.socket.is_set();
+        return this.socket.is_set();
     }
 
     async connect(participantName: string): Promise<SessionsSocket> {

--- a/src/components/planner/sidebar/sessionController/CollabModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabModal.tsx
@@ -67,7 +67,7 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
           id: sessionsSocket.sessionId,
           name: Math.random().toString(36).substr(2, 9),
           lastEdited: Date.now(),
-          expirationTime: new Date(sessionsSocket.sessionInfo['expiration_time']).getTime(),
+          expirationTime: sessionsSocket.sessionInfo['expiration_time'],
           currentUser: 'AnotherUser',
           link: `${window.location.origin}/planner?session=${sessionsSocket.sessionId}`,
           participants: sessionsSocket.sessionInfo['participants'],


### PR DESCRIPTION
Closes #660 

## What does this PR do?
Fixes two frontend bugs: ensured isConnected() in socket.ts returns based on connection state and expirationTime is now handled consistently in CollabModal.tsx.

## How to test
- **Bug 1:** After connecting to a session, open browser devtools console and run `sessionsSocket.isConnected()` -> it should return `true`.
- **Bug 2:** Create a session in Tab 1, join it from Tab 2 using the URL. Open localStorage in devtools (Application tab → Local Storage) and check the `collab-sessions` entry ->`expirationTime` should be the same value in both tabs and should be a reasonable future timestamp.


## Screenshots
<!-- Include before/after screenshots if there are UI changes -->
