### PR TITLE
feat: add text input to join a session by its code

### DIFF
--- a/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
@@ -17,7 +17,7 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
   const [error, setError] = useState('');
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value.toUpperCase();
+    const val = e.target.value.toUpperCase().trim();
 
     if (val && !/^[0-9A-Z]*$/.test(val)) {
       setError('Apenas números e letras são permitidos');
@@ -31,13 +31,13 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
   };
 
   const handleJoinClick = () => {
-    if (sessionCode.length == 4) {
+    if (sessionCode.length === 4) {
       onStartSession(sessionCode);
     }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key == 'Enter') {
+    if (e.key === 'Enter') {
       handleJoinClick();
     }
   }

--- a/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
@@ -36,6 +36,12 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key == 'Enter') {
+      handleJoinClick();
+    }
+  }
+
   return(
     <div className="text-center">
     <UserGroupIcon className="h-40 w-40 mx-auto text-primary" />
@@ -68,6 +74,7 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
             placeholder="Código" 
             value={sessionCode}
             onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
             className="uppercase text-center tracking-widest"
           />
           <Button 

--- a/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
@@ -2,6 +2,8 @@ import { PlayCircleIcon, UserGroupIcon } from '@heroicons/react/20/solid';
 import { Button } from '../../../ui/button';
 import { CollabSession } from '../../../../@types';
 import toHumanReadableTimeDiff from '../../../../utils/human-time';
+import { useState } from 'react';
+import { Input } from '../../../ui/input';
 
 type Props = {
   sessions: Array<CollabSession>,
@@ -10,8 +12,32 @@ type Props = {
   onDeleteSession: (arg: string | null) => void
 }
 
-const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDeleteSession }: Props) => (
-  <div className="text-center">
+const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDeleteSession }: Props) => {
+  const [sessionCode, setSessionCode] = useState('');
+  const [error, setError] = useState('');
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value.toUpperCase();
+
+    if (val && !/^[0-9A-Z]*$/.test(val)) {
+      setError('Apenas números e letras são permitidos');
+      return;
+    }
+
+    setError('');
+    if (val.length <= 4) {
+      setSessionCode(val);
+    }
+  };
+
+  const handleJoinClick = () => {
+    if (sessionCode.length == 4) {
+      onStartSession(sessionCode);
+    }
+  }
+
+  return(
+    <div className="text-center">
     <UserGroupIcon className="h-40 w-40 mx-auto text-primary" />
     <h3 className="text-xl font-bold leading-6 text-primary">
       Colaboração ao vivo...
@@ -34,6 +60,26 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
         Iniciar nova sessão
       </Button>
     </div>
+
+    <div className="mt-6 flex flex-col items-center justify-center space-y-2">
+        <div className="flex w-full max-w-[250px] items-center space-x-2">
+          <Input 
+            type="text" 
+            placeholder="Código" 
+            value={sessionCode}
+            onChange={handleInputChange}
+            className="uppercase text-center tracking-widest"
+          />
+          <Button 
+            onClick={handleJoinClick}
+            disabled={sessionCode.length < 4}
+            className="whitespace-nowrap"
+          >
+            Entrar
+          </Button>
+        </div>
+        {error && <span className="text-xs text-red-500 font-medium">{error}</span>}
+      </div>
 
     <div className="mt-6 text-center">
       <h4 className="text-md font-bold ">Sessões anteriores</h4>
@@ -66,6 +112,8 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
       </ul>
     </div>
   </div>
-);
+  )
+  
+};
 
 export default CollabPickSession;

--- a/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabPickSession.tsx
@@ -17,7 +17,7 @@ const CollabPickSession = ({ sessions, onStartSession, onCreateSession, onDelete
   const [error, setError] = useState('');
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value.toUpperCase().trim();
+    const val = e.target.value.toUpperCase().replace(/\s+/g, '');
 
     if (val && !/^[0-9A-Z]*$/.test(val)) {
       setError('Apenas números e letras são permitidos');

--- a/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
@@ -22,7 +22,8 @@ type Props = {
 
 const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => {
   const { toast } = useToast();
-  const [copied, setCopied] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedCode, setCopiedCode] = useState(false);
   const [lastValidUser, setLastValidUser] = useState(session.participants.find(p => p.client_id === sessionsSocket.clientId)?.name ?? '');
 
   const handleCopyLink = () => {
@@ -31,11 +32,23 @@ const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => 
       title: 'Link copiado',
       description: 'Podes partilhar o link com amigos para colaborar contigo.',
     });
-    setCopied(true);
+    setCopiedLink(true);
     setTimeout(() => {
-      setCopied(false);
+      setCopiedLink(false);
     }, 2000);
   };
+
+  const handleCopyCode = () => {
+    navigator.clipboard.writeText(session.id);
+    toast({
+      title: 'Código copiado',
+      description: 'Podes partilhar o código com amigos para colaborar contigo.'
+    });
+    setCopiedCode(true);
+    setTimeout(() => {
+      setCopiedCode(false);
+    }, 2000);
+  }
 
   const handleUserChange = (e) => {
     const newValue = e.target.value.trim();
@@ -71,6 +84,30 @@ const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => 
       </div>
 
       <div className="mt-4">
+        <label className="block text-sm font-medium text-gray-700 mb-1">Código da Sessão</label>
+        <div className="flex items-center mt-1">
+          <input
+            type="text"
+            value={session.id}
+            className="flex-1 block w-full rounded-md bg-gray-50 border-gray-300 shadow-sm sm:text-sm text-center font-mono font-bold tracking-wider"
+            readOnly
+          />
+          <Button
+            variant="icon"
+            className={`ml-2 px-3 py-1 flex items-center ${copiedCode ? 'bg-green-200 text-white' : 'bg-primary text-white'} text-sm font-medium rounded-lg min-w-[120px]`}
+            onClick={handleCopyCode}
+          >
+            {copiedCode ? (
+              <CheckIcon className="h-5 w-5 text-green-700" />
+            ) : (
+              <DocumentDuplicateIcon className="h-5 w-5" />
+            )}
+            {copiedCode ? '' : ' Copiar código'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4">
         <label className="block text-sm font-medium text-gray-700 mb-1">Link</label>
         <div className="flex items-center mt-1">
           <input
@@ -81,15 +118,15 @@ const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => 
           />
           <Button
             variant="icon"
-            className={`ml-2 px-3 py-1 flex items-center ${copied ? 'bg-green-200 text-white' : 'bg-primary text-white'} text-sm font-medium rounded-lg min-w-[120px]`}
+            className={`ml-2 px-3 py-1 flex items-center ${copiedLink ? 'bg-green-200 text-white' : 'bg-primary text-white'} text-sm font-medium rounded-lg min-w-[120px]`}
             onClick={handleCopyLink}
           >
-            {copied ? (
+            {copiedLink ? (
               <CheckIcon className="h-5 w-5 text-green-700" />
             ) : (
               <DocumentDuplicateIcon className="h-5 w-5" />
             )}
-            {copied ? '' : ' Copiar link'}
+            {copiedLink ? '' : ' Copiar link'}
           </Button>
         </div>
       </div>

--- a/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabSessionModal.tsx
@@ -48,7 +48,7 @@ const CollabSessionModal = ({ session, onExitSession, onUpdateUser }: Props) => 
     setTimeout(() => {
       setCopiedCode(false);
     }, 2000);
-  }
+  };
 
   const handleUserChange = (e) => {
     const newValue = e.target.value.trim();


### PR DESCRIPTION
Closes #663 

## What does this PR do?
Users now can manually join a session using a 4-character code, rather than relying solely on shared links. 
Added a validated input field in `CollabPickSession` (supporting A-Z and 0-9) and updated `CollabSessionModal` to display the session code with a "Copy" button. 

## Screenshots
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b116a231-4fe8-43d2-95b0-9994acdb6073" />
