### PR TITLE
feat: presence notifications when a participant joins or leaves a session

### DIFF
--- a/src/components/planner/sidebar/sessionController/CollabModal.tsx
+++ b/src/components/planner/sidebar/sessionController/CollabModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, Fragment } from 'react';
+import { useContext, useEffect, useRef, Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 import CollabPickSession from './CollabPickSession';
@@ -9,6 +9,7 @@ import { toast } from '../../../ui/use-toast';
 import { useSearchParams } from 'react-router-dom';
 import { uniqueNamesGenerator, adjectives, animals } from 'unique-names-generator';
 import useSession from '../../../../hooks/useSession';
+import { Participant } from '../../../../@types';
 
 type Props = {
   isOpen: boolean,
@@ -20,6 +21,7 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
   const currentSession = sessions.find(s => s.id === currentSessionId) || null;
   const [searchParams, ] = useSearchParams();
   const { signedIn: userSignedIn, user } = useSession();
+  const previousParticipantsRef = useRef<Participant[] | null>(null);
 
   useEffect(() => {
     if (searchParams.has('session')) {
@@ -29,14 +31,42 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
   }, []);
 
   const updatedSession = (sessionId: string, sessionInfo: any) => {
+    const newParticipants = sessionInfo['participants'] ?? [];
+    const previousParticipants = previousParticipantsRef.current ?? [];
+    const previousParticipantsById = new Map(previousParticipants.map(participant => [participant.client_id, participant]));
+    const newParticipantsById = new Map(newParticipants.map(participant => [participant.client_id, participant]));
+
+    newParticipants.forEach(participant => {
+      if (participant.client_id === sessionsSocket.clientId) {
+        return;
+      }
+
+      if (!previousParticipantsById.has(participant.client_id)) {
+        toast({
+          title: `${participant.name} entrou na sessão`,
+        });
+      }
+    });
+
+    previousParticipants.forEach(participant => {
+      if (!newParticipantsById.has(participant.client_id)) {
+        toast({
+          title: `${participant.name} saiu da sessão`,
+        });
+      }
+    });
+
+    previousParticipantsRef.current = newParticipants;
+
     setSessions(prevSessions =>
       prevSessions.map(session =>
-        session.id === sessionId ? { ...session, participants: sessionInfo['participants'] } : session
+        session.id === sessionId ? { ...session, participants: newParticipants } : session
       )
     );
   }
 
   const handleUnexpectedDisconnect = () => {
+    previousParticipantsRef.current = null;
     setCurrentSessionId(null);
     toast({ title: 'Foste desconectado inesperadamente', description: 'Por favor, tenta novamente mais tarde.' });
   };
@@ -87,10 +117,9 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
           newSession
         ]);
 
+        previousParticipantsRef.current = sessionsSocket.sessionInfo['participants'] ?? [];
         addSocketListeners(sessionsSocket);
         setCurrentSessionId(sessionsSocket.sessionId);
-
-        toast({ title: 'Entrou na sessão', description: 'Convida mais pessoas para se juntarem!'});
       })
       .catch(() => toast({ title: 'Erro ao entrar na sessão', description: 'Tente novamente mais tarde.' }));
   };
@@ -111,6 +140,7 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
         addSocketListeners(sessionsSocket);
         setCurrentSessionId(sessionsSocket.sessionId);
         setSessions(prevSessions => [...prevSessions, newSession]);
+        previousParticipantsRef.current = sessionsSocket.sessionInfo['participants'] ?? [];
 
         toast({ title: 'Sessão criada', description: 'Convida mais pessoas para se juntarem!'});
       })
@@ -118,6 +148,7 @@ const CollabModal = ({ isOpen, closeModal }: Props) => {
   };
 
   const handleExitSession = () => {
+    previousParticipantsRef.current = null;
     sessionsSocket.off('disconnect', handleUnexpectedDisconnect);
     sessionsSocket.disconnect();
     toast({ title: 'Sessão abandonada', description: 'Podes voltar a ela mais tarde, ou iniciar/entrar noutra sessão.'});


### PR DESCRIPTION
## Summary

- Shows a toast notification when a participant joins the session
- Shows a toast notification when a participant leaves the session
- Initialises `previousParticipantsRef` before registering socket listeners to avoid spurious join toasts on connect

## Notes

Retargets #727 onto `feature/collaborative-sessions` with only the presence-notification commit, without the full `develop` history.