### PR TITLE
Fix/planner full height

### DIFF
--- a/src/components/planner/Sidebar.tsx
+++ b/src/components/planner/Sidebar.tsx
@@ -39,7 +39,7 @@ const Sidebar = () => {
 
   return (
     <div
-      className="order-2 col-span-12 flex flex-col justify-between rounded-md bg-lightest px-3 py-3 dark:bg-dark lg:col-span-3 2xl:px-4 2xl:py-4
+      className="order-2 col-span-12 flex min-h-min flex-col justify-between rounded-md bg-lightest px-3 py-3 dark:bg-dark lg:col-span-3 lg:min-h-adjusted 2xl:px-4 2xl:py-4
                 h-[85vh] overflow-y-auto"
     >
       <div className="space-y-1">

--- a/src/pages/Exchange.tsx
+++ b/src/pages/Exchange.tsx
@@ -123,7 +123,7 @@ const ExchangePage = () => {
 
       <div className="grid w-cfull grid-cols-12 gap-x-4 gap-y-4 px-4 py-4">
         {/* Schedule Preview */}
-        <div className="lg:min-h-adjusted order-1 col-span-12 min-h-min rounded-sm bg-lightest px-6 py-6 dark:bg-dark lg:col-span-9 2xl:px-5 2xl:py-5  ">
+        <div className="lg:min-h-adjusted order-1 col-span-12 min-h-min rounded-sm bg-lightest px-3 py-3 dark:bg-dark lg:col-span-9 2xl:px-5 2xl:py-5  ">
           <div className="h-full w-full">
             {!sigarraSynced && !loadingSchedule && (
               <>

--- a/src/pages/TimeTableSelector.tsx
+++ b/src/pages/TimeTableSelector.tsx
@@ -85,19 +85,19 @@ const Content = () => {
         )}
         {sidebarPosition === 'left' ? (
           <>
-            <div className="col-span-12 lg:col-span-3 min-h">
+            <div className="col-span-12 min-h-min lg:col-span-3 lg:min-h-adjusted">
               <Sidebar />
             </div>
-            <div className="col-span-12 lg:col-span-9 min-h rounded-md bg-lightest px-3 py-3 dark:bg-dark 2xl:px-5 2xl:py-5">
+            <div className="col-span-12 min-h-min rounded-md bg-lightest px-3 py-3 dark:bg-dark lg:col-span-9 lg:min-h-adjusted 2xl:px-5 2xl:py-5">
               <PlannerSchedule />
             </div>
           </>
         ) : (
           <>
-            <div className="col-span-12 lg:col-span-9 min-h rounded-md bg-lightest px-3 py-3 dark:bg-dark 2xl:px-5 2xl:py-5">
+            <div className="col-span-12 min-h-min rounded-md bg-lightest px-3 py-3 dark:bg-dark lg:col-span-9 lg:min-h-adjusted 2xl:px-5 2xl:py-5">
               <PlannerSchedule />
             </div>
-            <div className="col-span-12 lg:col-span-3 min-h">
+            <div className="col-span-12 min-h-min lg:col-span-3 lg:min-h-adjusted">
               <Sidebar />
             </div>
           </>


### PR DESCRIPTION
Closes #738 

## Summary

- Fixed the Planner page so the white content area now fills the available screen height.
- Made the Planner page visually consistent with the Exchange page, removing the awkward empty gap at the bottom.

## Screenshots
<img width="953" height="438" alt="image" src="https://github.com/user-attachments/assets/5024932f-c130-4344-a3fe-7c06ec19e3b8" />

<img width="958" height="438" alt="image" src="https://github.com/user-attachments/assets/f7f89a7d-af93-41be-bdff-7e916a5ccf76" />

