### PR TITLE
fix: reorganize admin request card footer actions

### DIFF
--- a/src/components/admin/AdminMarketplaceExchangesCard.tsx
+++ b/src/components/admin/AdminMarketplaceExchangesCard.tsx
@@ -6,6 +6,7 @@ import { Person } from "./requests/cards/Person"
 import { RequestDate } from "./requests/cards/RequestDate"
 import { ArrowRightIcon, ChevronDownIcon, ChevronUpIcon, BadgeCheck, BadgeX, BadgeInfo   } from "lucide-react"
 import { AdminPreviewSchedule } from "./requests/AdminPreviewSchedule"
+import { TreatExchangeButton } from "./requests/cards/TreatExchangeButton"
 import useStudentsSchedule from "../../hooks/admin/useStudentsSchedule"
 import { ClassDescriptor, MarketplaceRequest } from "../../@types"
 import { AdminRequestCardFooter } from "./requests/cards/AdminRequestCardFooter"
@@ -38,6 +39,12 @@ export const AdminMarketplaceExchangesCard = ({
     const [exchangeState, setExchangeState] = useState(exchange);
 
     const { schedule } = useStudentsSchedule(exchange.issuer_nmec);
+
+    const courseId = exchange.options.map(option => option.course_info.course);
+    const courseInfo = exchange.options.map(option => ({
+        id: option.course_info.course,
+        acronym: option.course_info.acronym
+    }));
 
     return (
         <Card>
@@ -102,7 +109,7 @@ export const AdminMarketplaceExchangesCard = ({
                                     ))}
                                 </div>
                             </div>
-                            <div>
+                            <div className="flex gap-2">
                                 <AdminPreviewSchedule
                                     originalSchedule={schedule}
                                     classesToAdd={
@@ -114,6 +121,11 @@ export const AdminMarketplaceExchangesCard = ({
                                             }
                                         })
                                     }
+                                />
+                                <TreatExchangeButton
+                                    nmec={exchange.issuer_nmec}
+                                    courseId={courseId}
+                                    courseInfo={courseInfo}
                                 />
                             </div>
                         </div>
@@ -136,11 +148,6 @@ export const AdminMarketplaceExchangesCard = ({
                     requestType={AdminRequestType.URGENT_EXCHANGE}
                     requestId={exchange.id}
                     setExchange={setExchangeState}
-                    courseId={exchange.options.map(option => option.course_info.course)}
-                    courseInfo={exchange.options.map(option => ({
-                        id: option.course_info.course,
-                        acronym: option.course_info.acronym
-                    }))}
                 />
             }
         </Card>

--- a/src/components/admin/requests/cards/AdminRequestCardFooter.tsx
+++ b/src/components/admin/requests/cards/AdminRequestCardFooter.tsx
@@ -6,24 +6,14 @@ import { mailtoStringBuilder } from "../../../../utils/mail"
 import { Button } from "../../../ui/button"
 import { CardFooter } from "../../../ui/card"
 import { Separator } from "../../../ui/separator"
-import { AdminSendEmail } from "../AdminSendEmail"
-import { TreatExchangeButton } from "./TreatExchangeButton"
 import SessionContext from "../../../../contexts/SessionContext"
-
-type CourseInfo = {
-  id: number,
-  acronym: string
-}
 
 type Props = {
   nmecs: Array<string>,
   exchangeMessage: string,
   requestType: AdminRequestType,
   requestId: number,
-  showTreatButton?: boolean,
   setExchange?: Dispatch<SetStateAction<DirectExchangeRequest | UrgentRequest | CourseUnitEnrollment | MarketplaceRequest>>
-  courseId: Array<number>,
-  courseInfo?: Array<CourseInfo>
 }
 
 const rejectRequest = async (
@@ -98,11 +88,10 @@ export const AdminRequestCardFooter = ({
   exchangeMessage,
   requestType,
   requestId,
-  showTreatButton = true,
   setExchange,
-  courseId,
-  courseInfo
 }: Props) => {
+  const { user } = useContext(SessionContext);
+
   const awaitInfo = async () => {
     await markRequestAsAwaitingInformation(requestType, requestId);
     setExchange(prev => {
@@ -111,8 +100,6 @@ export const AdminRequestCardFooter = ({
       return newPrev;
     })
   }
-
-  const { user } = useContext(SessionContext);
 
   return <>
     <Separator className="my-4" />
@@ -145,28 +132,12 @@ export const AdminRequestCardFooter = ({
         Marcar como aceite
       </Button>
 
-      {showTreatButton &&
-        nmecs.map(nmec => (
-          <TreatExchangeButton
-            key={"treat-exchange-button-" + nmec}
-            nmec={nmec}
-            courseId={courseId}
-            courseInfo={courseInfo}
-          />
-        ))
-      }
-
-      <AdminSendEmail
-        nmec={nmecs}
-        requestType={requestType}
-        subject={
-          requestType === AdminRequestType.DIRECT_EXCHANGE || requestType === AdminRequestType.URGENT_EXCHANGE
-            ? "Pedido de troca de turma"
-            : "Pedido de Inscrição em Unidades Curriculares"
-        }
-        message={exchangeMessage}
+      <Button
+        variant="outline"
         onClick={awaitInfo}
-      />
+      >
+        Aguardar info
+      </Button>
     </CardFooter>
   </>
 }

--- a/src/components/admin/requests/cards/SingleStudentExchangeCard.tsx
+++ b/src/components/admin/requests/cards/SingleStudentExchangeCard.tsx
@@ -6,6 +6,7 @@ import { ArrowRightIcon, ChevronDownIcon, ChevronUpIcon} from "lucide-react";
 import { Person } from "./Person";
 import { ExchangeStatus } from "./ExchangeStatus";
 import { AdminPreviewSchedule } from "../AdminPreviewSchedule";
+import { TreatExchangeButton } from "./TreatExchangeButton";
 import { AdminRequestCardFooter } from "./AdminRequestCardFooter";
 import useStudentsSchedule from "../../../../hooks/admin/useStudentsSchedule";
 import { RequestDate } from "./RequestDate";
@@ -24,6 +25,12 @@ export const SingleStudentExchangeCard = ({
   const [exchangeState, setExchangeState] = useState(exchange);
 
   const { schedule } = useStudentsSchedule(exchange.issuer_nmec);
+
+  const courseId = exchange.options.map(option => option.course_info.course);
+  const courseInfo = exchange.options.map(option => ({
+    id: option.course_info.course,
+    acronym: option.course_info.acronym
+  }));
 
   return (
     <>
@@ -90,7 +97,7 @@ export const SingleStudentExchangeCard = ({
                     ))}
                   </div>
                 </div>
-                <div>
+                <div className="flex gap-2">
                   <AdminPreviewSchedule
                     originalSchedule={schedule}
                     classesToAdd={
@@ -103,6 +110,11 @@ export const SingleStudentExchangeCard = ({
                       })
                     }
 
+                  />
+                  <TreatExchangeButton
+                    nmec={exchange.issuer_nmec}
+                    courseId={courseId}
+                    courseInfo={courseInfo}
                   />
               </div>
             </div>
@@ -129,11 +141,6 @@ export const SingleStudentExchangeCard = ({
             requestType={AdminRequestType.URGENT_EXCHANGE}
             requestId={exchange.id}
             setExchange={setExchangeState}
-            courseId={exchange.options.map(option => option.course_info.course)}
-            courseInfo={exchange.options.map(option => ({
-              id: option.course_info.course,
-              acronym: option.course_info.acronym
-            }))}
           />
         }
       </Card>

--- a/src/components/admin/requests/cards/StudentEnrollmentCard.tsx
+++ b/src/components/admin/requests/cards/StudentEnrollmentCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "../../../ui/card"
 import { Person } from "./Person"
 import { useState } from "react"
 import { AdminPreviewSchedule } from "../AdminPreviewSchedule"
+import { TreatExchangeButton } from "./TreatExchangeButton"
 import { AdminRequestCardFooter } from "./AdminRequestCardFooter"
 import useStudentsSchedule from "../../../../hooks/admin/useStudentsSchedule"
 import { RequestDate } from "./RequestDate"
@@ -26,6 +27,12 @@ export const StudentEnrollmentCard = ({
     const [enrollmentState, setEnrollmentState] = useState(enrollment);
 
     const { schedule } = useStudentsSchedule(enrollment.user_nmec);
+
+    const courseId = enrollment.options.map(option => option.course_unit.course);
+    const courseInfo = enrollment.options.map(option => ({
+        id: option.course_unit.course,
+        acronym: option.course.acronym
+    }));
 
     return (
         <Card>
@@ -99,7 +106,7 @@ export const StudentEnrollmentCard = ({
                                         </div>
                                     ))}
                             </div>
-                            <div>
+                            <div className="flex gap-2">
                                 <AdminPreviewSchedule
                                     originalSchedule={schedule}
                                     classesToAdd={
@@ -111,6 +118,11 @@ export const StudentEnrollmentCard = ({
                                             }
                                         })
                                     }
+                                />
+                                <TreatExchangeButton
+                                    nmec={enrollment.user_nmec}
+                                    courseId={courseId}
+                                    courseInfo={courseInfo}
                                 />
                             </div>
                         </div>
@@ -135,11 +147,6 @@ export const StudentEnrollmentCard = ({
                         requestType={AdminRequestType.ENROLLMENT}
                         requestId={enrollment.id}
                         setExchange={setEnrollmentState}
-                        courseId={enrollment.options.map(option => option.course_unit.course)}
-                        courseInfo={enrollment.options.map(option => ({
-                            id: option.course_unit.course,
-                            acronym: option.course.acronym
-                        }))}
                     />
                 }
             


### PR DESCRIPTION
Closes #

## What does this PR do?
Removed the standalone Email button — it was a "request more info" flow, not a state-changing action.
Added an Aguardar info button to the footer to handle this directly.
Moved the Tratar button next to Visualizar (schedule preview).
Footer now only shows the 3 state-changing actions: Rejeitar, Marcar como aceite, Aguardar info.

## Screenshots
<img width="1899" height="1090" alt="Screenshot From 2026-09-02 22-40-30" src="https://github.com/user-attachments/assets/35291d2e-5d33-4970-b5a1-7c28d220b9b9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Treat Exchange** action to student exchange, enrollment, and marketplace exchange cards.
  - Administrators can now access exchange treatment actions directly alongside schedule information.

- **Improvements**
  - Added an **Aguardar info** (“Awaiting information”) action directly within request card controls.
  - Updated action layouts for clearer spacing and easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->